### PR TITLE
Add autoCapitalize on textInput

### DIFF
--- a/components/Autocomplete/index.js
+++ b/components/Autocomplete/index.js
@@ -171,6 +171,7 @@ class Autocomplete extends Component {
       placeholderColor,
       data,
       disableFullscreenUI,
+      autoCapitalize,
       ...dropdownProps
     } = this.props;
 
@@ -191,6 +192,7 @@ class Autocomplete extends Component {
             autoCorrect={autoCorrect}
             keyboardType={keyboardType}
             onChangeText={text => this.handleInputChange(text)}
+            autoCapitalize={autoCapitalize}
             onFocus={event => {
               if (scrollToInput) {
                 scrollToInput(findNodeHandle(event.target));


### PR DESCRIPTION
I am using this plugin in my application and find it very useful and well done.
I have to set autoCapitalize to "none", but this possibility doesn't currently exist.
I modified the code to do this.
I hope it is appreciated