### PR TITLE
Pass onSubmitEditing to TextInput on Autocomplete

### DIFF
--- a/components/Autocomplete/index.js
+++ b/components/Autocomplete/index.js
@@ -196,6 +196,7 @@ class Autocomplete extends Component {
                 scrollToInput(findNodeHandle(event.target));
               }
             }}
+            onSubmitEditing={this.props.onSubmitEditing}
           />
           {loading && (
             <ActivityIndicator

--- a/components/Autocomplete/index.js
+++ b/components/Autocomplete/index.js
@@ -197,6 +197,7 @@ class Autocomplete extends Component {
               }
             }}
             onSubmitEditing={this.props.onSubmitEditing}
+            returnKeyType={this.props.returnKeyType}
           />
           {loading && (
             <ActivityIndicator

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,6 +46,7 @@ type AutocompleteProps = {
     rightTextExtractor?: (item: any) => void;
     fetchData?: (search: string) => Promise<any[]>;
     onSubmitEditing?: TextInputProps["onSubmitEditing"];
+    returnKeyType?: TextInputProps["returnKeyType"];
 }
 
 export class Autocomplete extends React.Component<AutocompleteProps, any> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for react-native-dropdown-autocomplete 1.0
 
 import * as React from 'react';
-import { ViewStyle, TextStyle, StyleProp, KeyboardTypeOptions } from 'react-native';
+import { ViewStyle, TextStyle, StyleProp, KeyboardTypeOptions, TextInputProps } from 'react-native';
 
 type AutocompleteProps = {
     autoCorrect?: boolean;
@@ -45,6 +45,7 @@ type AutocompleteProps = {
     valueExtractor?: (item: any) => void;
     rightTextExtractor?: (item: any) => void;
     fetchData?: (search: string) => Promise<any[]>;
+    onSubmitEditing?: TextInputProps["onSubmitEditing"];
 }
 
 export class Autocomplete extends React.Component<AutocompleteProps, any> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@laurabeatris/react-native-dropdown-autocomplete",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "author": "maxkordiyak",
   "repository": "maxkordiyak/react-native-dropdown-autocomplete",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-dropdown-autocomplete",
+  "name": "@laurabeatris/react-native-dropdown-autocomplete",
   "version": "1.0.16",
   "author": "maxkordiyak",
   "repository": "maxkordiyak/react-native-dropdown-autocomplete",


### PR DESCRIPTION
The ``Autocomplete`` component didn't receive the ``onSubmitEditing`` prop and it wasn't possible to execute a logic to focus on the next input of a form. 

